### PR TITLE
[fix]フォームの送信方法_2

### DIFF
--- a/public/js/geo.js
+++ b/public/js/geo.js
@@ -1,21 +1,38 @@
+"use strict";
+
 const addressInput = document.getElementById("address");
 const latInput = document.getElementById("lat");
 const lngInput = document.getElementById("lng");
+const postForm = document.getElementById("post-form");
+let errorMessage = document.getElementById("error-message");
 
-addressInput.addEventListener("change", () => {
+// エンターキーでの送信をキャンセル
+postForm.addEventListener("submit", (e) => {
+    e.preventDefault();
+});
+
+function submitForm() {
+    if (!addressInput.value.trim()) {
+        errorMessage.textContent = "*住所は入力必須です";
+        errorMessage.style.display = "block";
+        return;
+    }
+
+    //エラーメッセージを消す
+    errorMessage.style.display = "none";
+
     const geocoder = new google.maps.Geocoder();
     geocoder.geocode({ address: addressInput.value }, (results, status) => {
         if (status == "OK") {
             const location = results[0].geometry.location;
             latInput.value = location.lat();
             lngInput.value = location.lng();
+
+            //緯度・経度が入力されたらフォーム送信
+            postForm.submit();
         } else {
-            alert("住所が見つかりません：" + status);
+            errorMessage.textContent = "住所が見つかりません";
+            errorMessage.style.display = "block";
         }
     });
-});
-
-function submitForm() {
-    const form = document.getElementById('post-form');
-    form.submit();
 }

--- a/public/style.css
+++ b/public/style.css
@@ -1,3 +1,8 @@
 #map {
     height: 500px;
 }
+
+#error-message {
+    color: red;
+    display: none;
+}

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -3,16 +3,12 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="stylesheet" href="{{ url('style.css') }}" />
         <title>RescueDog Create</title>
     </head>
     <body>
         <h1>投稿ページ</h1>
-        <form
-            id="post-form"
-            method="POST"
-            action="{{ route('posts.store') }}"
-            onsubmit="return false;"
-        >
+        <form id="post-form" method="POST" action="{{ route('posts.store') }}">
             @csrf
             <!-- <div>
                 <label> 画像(仮) </label>
@@ -25,6 +21,8 @@
 
                 <input type="hidden" name="lat" id="lat" />
                 <input type="hidden" name="lng" id="lng" />
+
+                <div id="error-message"></div>
             </div>
             <!-- <div>
                 <label>


### PR DESCRIPTION
■フォームの送信方法を修正

[問題]
①住所入力後、すぐに投稿ボタンを押下
　⇒緯度・経度が未取得の状態で送信されてしまう事案発生
②エンターキー押下での送信に不具合あり

[修正内容]
①changeイベントが原因のため削除し、submitForm()でひとくくりに
　⇒「緯度・経度が確実に取得後、フォームを送信」が実現
②preventDefaultで制御

[その他]
・バリデーションを追加（エラーメッセージ）