### PR TITLE
[add]投稿画損の保存処理

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -46,6 +46,10 @@ class PostController extends Controller
 
     public function update(Request $request, Post $post)
     {
+        // 投稿画像をstorage/imagesに保存（自動でユニークな名前を割り当てる）
+        $path = $request->file('image')->store('images', 'public');
+
+        $post->image_path = $path;
         $post->address = $request->address;
         $post->lat = $request->lat;
         $post->lng = $request->lng;


### PR DESCRIPTION
投稿画像を public/storage/imagesに保存
（postsテーブルにはimage_pathとして格納される）