### PR TITLE
[comment]詳細ページ：不要と思われる記述をコメントアウト

### DIFF
--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -24,7 +24,7 @@
     
     <p>{!! nl2br(e($post->address)) !!}</p>
 
-    <p><a href="{{ route('dashboard') }}">マイページへ戻る</a></p>
+    <!-- <p><a href="{{ route('dashboard') }}">マイページへ戻る</a></p> -->
   </body>
 
   <script>


### PR DESCRIPTION
「マイページへ戻る」リンク：
必要性を感じない。
トップページに戻る、と勘違いしてクリックしてしまうので煩わしい。
実ユーザーも同じ状況になると考えられるため不要と判断。