### PR TITLE
[update]編集フォームに共通化ファイル適用

### DIFF
--- a/resources/views/components/common-form.blade.php
+++ b/resources/views/components/common-form.blade.php
@@ -23,11 +23,8 @@
                 class="w-[500px] h-[30px]" 
                 value="{{ old('address', isset($post) ? $post->address : '') }}"/>
           </label>
-
-          <input type="hidden" name="lat" id="lat" value="{{ old('lat', isset($post) ? $post->lat : '') }}"/>
-          <input type="hidden" name="lng" id="lng" value="{{ old('lng', isset($post) ? $post->lng : '') }}"/>
-          
-              <input type="text" name="address" id="address" class="w-[500px] h-[30px]"/>
+            <input type="hidden" name="lat" id="lat" value="{{ old('lat', isset($post) ? $post->lat : '') }}"/>
+            <input type="hidden" name="lng" id="lng" value="{{ old('lng', isset($post) ? $post->lng : '') }}"/>
           </label>
 
           <div id="error-message"></div>

--- a/resources/views/posts/edit-post.blade.php
+++ b/resources/views/posts/edit-post.blade.php
@@ -10,6 +10,7 @@
     :formAction="route('posts.update', $post)"
     submitLabel="編集完了"
     :backLink="route('posts.show', $post)"
+    :post="$post"
 >
 
     <div class="m-4">

--- a/resources/views/posts/edit-post.blade.php
+++ b/resources/views/posts/edit-post.blade.php
@@ -4,20 +4,18 @@
 
 @section('content')
 
-    @include('components.common-form', [
-    'formTitle' => '編集フォーム',
-    'formMethod' => 'PATCH',
-    'formAction' => route('posts.update', $post),
-    'submitLabel' => '編集完了',
-    'backLink' => route('posts.show', $post),
-    ])
+<x-common-form
+    formTitle="編集フォーム"
+    formMethod="PATCH"
+    :formAction="route('posts.update', $post)"
+    submitLabel="編集完了"
+    :backLink="route('posts.show', $post)"
+>
 
-    <script
-        src="https://maps.googleapis.com/maps/api/js?key={{
-            config('services.google_maps.api_key')
-        }}"
-        async
-        defer
-    ></script>
-    <script src="{{ url('/js/geo.js') }}"></script>
+    <div class="m-4">
+        <label class="block">画像：</label>
+        <input type="file" name="image" alt="画像" />
+    </div>
+</x-common-form>
+
 @endsection


### PR DESCRIPTION
- 画像を編集してみたが、元の画像のままになってしまっている。
⇒やはり画像部分も共通化に含めてしまってよさそう。
　コントローラーのupdateメソッドを更新する必要がありそう
　⇒住所も更新されない…　$formMethod　に問題ありかも。ここはPOSTで固定しておく必要ありそう。。。


- 編集ページ
住所欄は前回の値を保持したいが空欄のままになってしまっていた
💡$postを渡すことで解決： #[78345c7]
　コントローラー⇒ビューへ変数を渡すことは可能だが、コンポーネントには渡らないため、上記事象が発生していた