### PR TITLE
[delete]web.php：不要な記述を削除

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -34,18 +34,6 @@ Route::post('posts/{post}/found', [PostController::class, 'found'])->name('posts
  * ログイン認証用ルート
  * *************************************** */
 
-// Breezeの認証ルートを読み込む
+// ログイン認証用ルートを読み込む
 require __DIR__.'/auth.php';
-
-// マイページ編集用ルートを読み込む
-// require __DIR__.'/profile.php';
-
-Route::get('/profile/edit', function () {
-    return view('profile.edit-profile');
-})->name('profile.edit');
-
-Route::get('/logout-test', function () {
-    \Illuminate\Support\Facades\Auth::logout();
-    return redirect('/');
-});
 


### PR DESCRIPTION
ログイン関連のルートは、auth.phpに含めたいため。
web.phpではauth.phpの読み込みだけする。