### PR TITLE
[update]マイページ：タブ切り替え表示を適用

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -3,28 +3,52 @@
 @section('title', 'マイぺージ/RescueDog')
 
 @section('content')
+<div class="bg-white" x-data="{ activeTab: 'myPosts' }">
+    <nav class="flex flex-col sm:flex-row">
+        <!-- タブ切り替えボタン -->
+        <button
+            @click="activeTab = 'myPosts'"
+            :class="activeTab === 'myPosts' 
+            ? 'border-b-2 border-blue-600 text-blue-600 font-semibold' 
+            : 'text-gray-500 hover:text-blue-600'"
+            class="py-2 px-4 transition duration-300"
+        >
+            現在の投稿一覧
+        </button>
 
-<div class="p-6 text-gray-900">
-    <div class="text-3xl p-4">
-        現在の投稿一覧
+        <button
+            :class="activeTab === 'profile' 
+            ? 'border-b-2 border-blue-600 text-blue-600 font-semibold' 
+            : 'text-gray-500 hover:text-blue-600'"
+            class="py-2 px-4 transition duration-300"
+            @click="activeTab = 'profile'"
+        >
+            プロフィール
+        </button>
+    </nav>
+
+    <!-- 投稿一覧の表示 -->
+    <div x-show="activeTab === 'myPosts'" class="p-4">
+        <ul class="flex gap-6 flex-wrap">
+            @forelse ($posts as $post)
+                <li class="hover:opacity-50">
+                    <a href="{{ route('posts.show', $post) }}">
+                        @if ($post->image_path)
+                            <img src="{{ asset('storage/' . $post->image_path) }}" alt="投稿画像" class="w-64 h-64 object-cover rounded-md">
+                        @else
+                            <img src="{{ asset('images/NoImage.png') }}" alt="画像なし" class="w-64 h-64 object-cover rounded-md">
+                        @endif
+                    </a>
+                </li>
+            @empty
+                <li>まだ投稿していません</li>
+            @endforelse
+        </ul>
     </div>
 
-    <ul class="p-4 flex gap-20">
-        @forelse ($posts as $post)
-            <li class="hover:opacity-50">
-                <a href="{{ route('posts.show', $post) }}">
-                    @if ($post->image_path)
-                        <img src="{{ asset('storage/' . $post->image_path) }}" alt="投稿画像" class="w-64 h-64 object-cover rounded-md">
-                    @else
-                        <img src="{{ asset('images/NoImage.png') }}" alt="画像なし" class="w-64 h-64 object-cover rounded-md">
-                    @endif
-                </a>
-            </li>
-        @empty
-            <li>まだ投稿していません</li>
-        @endforelse
-    </ul>
-    <a href="{{ route('profile.edit') }}" class="btn btn-primary">プロフィールを編集</a>
-
+    <!-- ユーザープロフィールの表示 -->
+    <div x-show="activeTab === 'profile'" class="p-4">
+        @include('profile.edit-profile', ['user' => Auth::user()])
+    </div>
 </div>
 @endsection


### PR DESCRIPTION
- 投稿一覧
- プロフィール
⇒タブ切り替えで表示

✅改善必要
- ユーザー情報の再設定：保存ボタン押下後、ヘッダーが消えてしまう
- パスワードの再設定後：画面遷移してしまう&メッセージエラーが出ている