### PR TITLE
[update]プロフィールを編集後：ページはそのまま＆フラッシュメッセージを出すように

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -34,7 +34,7 @@ class ProfileController extends Controller
 
         $request->user()->save();
 
-        return Redirect::route('profile.edit')->with('status', 'profile-updated');
+        return redirect()->route('dashboard', ['activeTab' => 'profile'])->with('flashSuccess', '正常に保存されました');
     }
 
     /**

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -3,7 +3,7 @@
 @section('title', 'マイぺージ/RescueDog')
 
 @section('content')
-<div class="bg-white" x-data="{ activeTab: 'myPosts' }">
+<div class="bg-white" x-data="{ activeTab: '{{ request('activeTab', 'myPosts') }}' }">
     <nav class="flex flex-col sm:flex-row">
         <!-- タブ切り替えボタン -->
         <button
@@ -29,7 +29,7 @@
 
     <!-- 投稿一覧の表示 -->
     <div x-show="activeTab === 'myPosts'" class="p-4">
-        <ul class="flex gap-6 flex-wrap">
+        <ul class="flex gap-6 flex-wrap p-6">
             @forelse ($posts as $post)
                 <li class="hover:opacity-50">
                     <a href="{{ route('posts.show', $post) }}">


### PR DESCRIPTION
プロフィール編集画面
- 保存ボタン押下後：
　- 投稿一覧にリロードしてしまっていた⇒遷移しないように更新
　- 正常に保存された場合はフラッシュメッセージを表示

 