### PR TITLE
[update]プロフィール編集画面：フラッシュメッセージを表示するため、「保存しました」は不要

### DIFF
--- a/resources/views/profile/partials/update-password-form.blade.php
+++ b/resources/views/profile/partials/update-password-form.blade.php
@@ -34,7 +34,7 @@
         <div class="flex items-center gap-4">
             <x-primary-button>{{ __('保存') }}</x-primary-button>
 
-            @if (session('status') === 'password-updated')
+            <!-- @if (session('status') === 'password-updated')
                 <p
                     x-data="{ show: true }"
                     x-show="show"
@@ -42,7 +42,7 @@
                     x-init="setTimeout(() => show = false, 2000)"
                     class="text-sm text-gray-600"
                 >{{ __('保存しました') }}</p>
-            @endif
+            @endif -->
         </div>
     </form>
 </section>

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -50,7 +50,7 @@
         <div class="flex items-center gap-4">
             <x-primary-button>{{ __('保存') }}</x-primary-button>
 
-            @if (session('status') === 'profile-updated')
+            <!-- @if (session('status') === 'profile-updated')
                 <p
                     x-data="{ show: true }"
                     x-show="show"
@@ -58,7 +58,7 @@
                     x-init="setTimeout(() => show = false, 2000)"
                     class="text-sm text-gray-600"
                 >{{ __('保存しました') }}</p>
-            @endif
+            @endif -->
         </div>
     </form>
 </section>


### PR DESCRIPTION
保存ボタン押下後：
ボタン横に「保存しました」が表示されていたが、フラッシュメッセージを表示するため不要とする