### PR TITLE
[add]コメント投稿機能のために、commentsテーブルと、commentモデルを追加

### DIFF
--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Comment extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'post_id',
+        'body',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function post()
+    {
+        return $this->belongsTo(Post::class);
+    }
+}

--- a/database/migrations/2025_08_03_154600_create_comments_table.php
+++ b/database/migrations/2025_08_03_154600_create_comments_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('comments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('post_id')->constrained()->onDelete('cascade');
+            $table->text('body');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('comments');
+    }
+};


### PR DESCRIPTION
commentsテーブル

<カラム>
id
user_id (外部キー：usersテーブルのidを参照)
post_id (外部キー：postsテーブルのidを参照)
body
created_at
updated_at
