### PR TITLE
[style]返信：ユーザー名の表示は太字不要

### DIFF
--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -202,7 +202,7 @@
                     <img src="{{ asset('storage/' . optional($reply->user)->profile_image ?? 'profile_images/default_profile.png') }}"
                         class="w-8 h-8 rounded-full object-cover">
                     <div class="ml-2">
-                      <p class="font-bold text-sm">{{ $reply->user->name }}</p>
+                      <p class="text-sm">{{ $reply->user->name }}</p>
                       <p class="text-gray-500 text-xs">{{ $reply->created_at->format('Y-m-d H:i') }}</p>
                       <p class="text-sm mt-1">{!! nl2br(e($reply->body)) !!}</p>
                     </div>


### PR DESCRIPTION
太字表示にしていたが不要のため、font-boldは削除