### PR TITLE
[fix]未読通知のみを取得するように修正

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -56,9 +56,10 @@ class AuthenticatedSessionController extends Controller
         //投稿一覧を表示
         $posts = Post::where('user_id', auth()->id())->get(); 
 
-        // ログインユーザーの通知を取得（未読も既読も含む）
+        // ログインユーザーの通知を取得（未読通知のみ）
         $notifications = auth()->user()->notifications()
         ->with(['comment.user', 'reply.user']) // 関連リレーションの eager loading
+        ->where('is_read', false)
         ->latest()
         ->get();
 


### PR DESCRIPTION
ビュー側の処理がうまくいかない
＝未読通知がない場合は「新着通知はありません」を表示したいが、全通知（既読+未読）を取得してしまうと、うまく表示できないため