### PR TITLE
[fix] 「コメントはまだありません」が表示されない問題を解消

### DIFF
--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -155,7 +155,7 @@
         </button>
       @endif
       <!-- コメントを一覧表示 -->
-      <div id="comment-list" class="hidden">
+      <div id="comment-list" class="{{ $post->comments->count() > 0 ? 'hidden' : '' }}">
         @forelse ($post->comments as $comment)
           <div class="border p-2 my-2">
             <div class="flex">


### PR DESCRIPTION
コメント一覧のdiv classにhiddenがかけられていたため。
- 1件以上のときはhidden（＝トグル対応）
- 0件の時はhiddenにしない